### PR TITLE
Get rid of deprecation notice for StreamedResponseListener

### DIFF
--- a/src/Bridge/Symfony/HttpFoundation/StreamedResponseListener.php
+++ b/src/Bridge/Symfony/HttpFoundation/StreamedResponseListener.php
@@ -44,7 +44,7 @@ class StreamedResponseListener implements EventSubscriberInterface
         $this->delegate->onKernelResponse($event);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => ['onKernelResponse', -1024],


### PR DESCRIPTION
There is deprecation notice returned by Symfony's `DebugClassLoader`:

> Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "K911\Swoole\Bridge\Symfony\HttpFoundation\StreamedResponseListener" now to avoid errors or add an explicit @return annotation to suppress this message

Adding native return type is fully compatible and will clean that notice.